### PR TITLE
feat: implement sprint 2 inner problem improvements

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -50,12 +50,12 @@ Deliverables: robust loader, alignment report per sortie, cached processed files
 
 ### Sprint 2 (Inner problem stability & performance)
 Goals: Improve numerical stability, exploit structure, reduce runtime.
-- [ ] Precompute and reuse step matrices for constant Δt; vectorize dynamics constraints generation.
-- [ ] Add banded/Toeplitz structure exploitation for second-difference operators; use CVXPY `cp.diff` where helpful.
-- [ ] Calibrate scaling (α_p, α_v) to keep residuals near O(1); auto-suggest values from data magnitudes.
-- [ ] Tighten solver tolerances adaptively (ECOS/OSQP) based on feasibility residuals; expose via config.
-- [ ] Add optional quadratic TV (QP) vs ℓ2-TV (SOCP) switch to speed QP path.
-- [ ] Add diagnostics: feasibility residuals by constraint family; terminal v_zN check when SOC active.
+- [x] Precompute and reuse step matrices for constant Δt; vectorize dynamics constraints generation.
+- [x] Add banded/Toeplitz structure exploitation for second-difference operators; use CVXPY `cp.diff` where helpful.
+- [x] Calibrate scaling (α_p, α_v) to keep residuals near O(1); auto-suggest values from data magnitudes.
+- [x] Tighten solver tolerances adaptively (ECOS/OSQP) based on feasibility residuals; expose via config.
+- [x] Add optional quadratic TV (QP) vs ℓ2-TV (SOCP) switch to speed QP path.
+- [x] Add diagnostics: feasibility residuals by constraint family; terminal v_zN check when SOC active.
 
 Deliverables: faster stable solves, diagnostic logs, config toggles for TV type and tolerances.
 

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -5,10 +5,12 @@ from src.model import discrete_step_matrices, G0
 def test_small_k_series_matches_limit():
     k = 1e-8
     dt = 0.1
-    A, B, Cmag = discrete_step_matrices(k, dt)
+    A, B, Cmag, gmag = discrete_step_matrices(k, dt)
     # As k->0, e^{-k dt} ~ 1 - k dt
     assert np.allclose(np.diag(A), 1 - k * dt, atol=1e-6)
     # (1 - e^{-k dt})/k ~ dt
     assert np.isclose(B[0, 0], dt, atol=1e-6)
     # Cmag ~ 0.5 g dt^2
     assert np.isclose(Cmag, 0.5 * G0 * dt * dt, atol=1e-6)
+    # g_step magnitude ~ g dt
+    assert np.isclose(gmag, G0 * dt, atol=1e-6)


### PR DESCRIPTION
## Summary
- add auto-scaling and solver diagnostics for inner QP/SOCP model
- cache step matrices, vectorize dynamics and expose quadratic TV option
- tighten solver tolerances adaptively and update sprint plan

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ff268e708329a06247667d506223