### PR TITLE
Add ECDF/histogram figure and update sprint plan

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -71,7 +71,13 @@ Deliverables: faster outer loop, landscape figure, resumable state.
 
 ### Sprint 4 (Evaluation, ablations, and figures)
 Goals: Complete F1–F9 and ablations; statistical tests.
-- [ ] Implement remaining figures: ECDF/hist (F3), CEP curves (F4), θ_max sensitivity (F5), runtime (F7), kinematics sanity (F8), impact-angle hist (F9).
+- [ ] Implement remaining figures:
+  - [x] ECDF/hist (F3)
+  - [ ] CEP curves (F4)
+  - [ ] θ_max sensitivity (F5)
+  - [ ] runtime (F7)
+  - [ ] kinematics sanity (F8)
+  - [ ] impact-angle hist (F9)
 - [ ] Implement T3–T5 tables: ablations (SOC on/off; θ_max; grid density), runtime breakdown, solver settings.
 - [ ] Add paired Wilcoxon tests for Raw vs QP and QP vs QP+SOC; annotate p-values on F4.
 - [ ] Aggregate across sorties: median [IQR] with confidence intervals.

--- a/src/figures.py
+++ b/src/figures.py
@@ -51,9 +51,45 @@ def fig_error_timeseries(t: np.ndarray, d_raw: np.ndarray, d_qp: np.ndarray, d_s
     if d_soc is not None:
         ax.plot(t, d_soc, color=colors[3], label="QP+SOC")
     ax.set_xlabel("t [s]")
-    ax.set_ylabel(r"$\lVert p - \hat{p} \rVert$ [m]")
+    ax.set_ylabel(r"$\|p - \hat{p}\|$ [m]")
     ax.legend()
     _save(fig, out_dir, "fig_F2_time_series_errors")
+
+
+def fig_error_ecdf_hist(d_raw: np.ndarray, d_qp: np.ndarray, d_soc: Optional[np.ndarray], out_dir: str) -> None:
+    """Plot error ECDF and histogram (F3)."""
+    set_pub_style()
+    colors = palette()
+    fig, (ax_ecdf, ax_hist) = plt.subplots(1, 2, figsize=(8, 3))
+
+    def _ecdf(ax: plt.Axes, data: np.ndarray, color: str, label: str) -> None:
+        x = np.sort(data)
+        y = np.linspace(0.0, 1.0, len(x), endpoint=False)
+        ax.step(x, y, where="post", color=color, label=label)
+
+    _ecdf(ax_ecdf, d_raw, colors[1], "Raw")
+    _ecdf(ax_ecdf, d_qp, colors[2], "QP")
+    if d_soc is not None:
+        _ecdf(ax_ecdf, d_soc, colors[3], "QP+SOC")
+    ax_ecdf.set_xlabel(r"$\|p - \hat{p}\|$ [m]")
+    ax_ecdf.set_ylabel("ECDF")
+    ax_ecdf.set_title("Error ECDF")
+    ax_ecdf.legend()
+
+    max_val = max(
+        np.max(d_raw), np.max(d_qp), np.max(d_soc) if d_soc is not None else 0.0
+    )
+    bins = np.linspace(0.0, max_val, 30)
+    ax_hist.hist(d_raw, bins=bins, color=colors[1], alpha=0.5, label="Raw")
+    ax_hist.hist(d_qp, bins=bins, color=colors[2], alpha=0.5, label="QP")
+    if d_soc is not None:
+        ax_hist.hist(d_soc, bins=bins, color=colors[3], alpha=0.5, label="QP+SOC")
+    ax_hist.set_xlabel(r"$\|p - \hat{p}\|$ [m]")
+    ax_hist.set_ylabel("Count")
+    ax_hist.set_title("Error Histogram")
+    ax_hist.legend()
+
+    _save(fig, out_dir, "fig_F3_error_ecdf_hist")
 
 
 def fig_outer_landscape(history: List[Dict], out_dir: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure repository root is on sys.path for src imports
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -1,0 +1,15 @@
+import matplotlib
+matplotlib.use('Agg')
+
+import numpy as np
+from src.figures import fig_error_ecdf_hist
+
+
+def test_fig_error_ecdf_hist(tmp_path):
+    rng = np.random.default_rng(0)
+    d_raw = np.abs(rng.normal(size=100))
+    d_qp = np.abs(rng.normal(scale=0.8, size=100))
+    d_soc = np.abs(rng.normal(scale=0.5, size=100))
+    fig_error_ecdf_hist(d_raw, d_qp, d_soc, str(tmp_path))
+    assert (tmp_path / 'fig_F3_error_ecdf_hist.png').exists()
+    assert (tmp_path / 'fig_F3_error_ecdf_hist.pdf').exists()


### PR DESCRIPTION
## Summary
- add ECDF/histogram visualization (F3) for error distributions
- mark F3 figure as complete in sprint 4 plan
- cover new figure with tests ensuring images are generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b701b89c3c8329bac79bc7006186ac