### PR TITLE
feat: add input normalization utility

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -5,6 +5,11 @@ paths:
   telemetry_csv: "Telemetric Output Conversion.csv"
   out_dir: "outputs/run_$(date +%Y%m%d_%H%M%S)"
 
+general:
+  enable_scaling: true
+  scale_position_m: 1e3
+  scale_velocity_mps: 10.0
+
 mapping:
   # Robust column mapping: project-specific names to canonical {time, lat, lon, alt, vx, vy, vz, doppler, slant_range}
   radar:

--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ from src.utils import (
     check_error_sanity,
     check_position_scale,
     clean_runtime_breakdown,
+    normalize_inputs,
 )
 
 
@@ -460,6 +461,11 @@ def run_once(args: argparse.Namespace) -> None:
         enforce=enforce,
         hard_max_m=hard_max,
     )
+    _, unit_summary = normalize_inputs(
+        {"positions": processed.radar_xyz, "velocities": processed.telem_vxyz},
+        cfg,
+    )
+    print("Unit summary:", json.dumps(unit_summary, indent=2))
     load_time = time.time() - load_start
 
     # Optional pre-alignment of radar frame to telemetry frame (position offset)


### PR DESCRIPTION
## Summary
- add configurable scaling defaults for positions and velocities
- introduce `normalize_inputs` utility with unit magnitude summaries
- print unit summary in main execution and test normalization behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b74b2275e483298e37333428e3676b