### PR TITLE
Expose configurable terminal constraints with soft penalties

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -49,8 +49,10 @@ solver:
   alpha_v: null
   enable_soc: true
   theta_max_deg: 20
-  terminal_altitude_window_m: [ -500.0, 500.0 ]
-  terminal_xy_box_m: 8000.0
+  alt_window_m: [ -500.0, 500.0 ]
+  xy_box_m: 8000.0
+  alt_slack_penalty: 0.0
+  xy_slack_penalty: 0.0
   osqp:
     eps_abs: 2.0e-5
     eps_rel: 2.0e-5

--- a/main.py
+++ b/main.py
@@ -105,8 +105,10 @@ def run_ablation_studies(
     sopts_qp = SolverOptions(
         enable_soc=False,
         theta_max_deg=cfg["solver"].get("theta_max_deg", 15),
-        terminal_altitude_window_m=tuple(cfg["solver"].get("terminal_altitude_window_m", [-5, 5])),
-        terminal_xy_box_m=float(cfg["solver"].get("terminal_xy_box_m", 500.0)),
+        alt_window_m=tuple(cfg["solver"].get("alt_window_m", [-5, 5])),
+        xy_box_m=float(cfg["solver"].get("xy_box_m", 500.0)),
+        alt_slack_penalty=float(cfg["solver"].get("alt_slack_penalty", 0.0)),
+        xy_slack_penalty=float(cfg["solver"].get("xy_slack_penalty", 0.0)),
         osqp_opts=cfg["solver"].get("osqp", {}),
         ecos_opts=cfg["solver"].get("ecos", {}),
     )
@@ -134,8 +136,10 @@ def run_ablation_studies(
         sopts_soc = SolverOptions(
             enable_soc=True,
             theta_max_deg=cfg["solver"].get("theta_max_deg", 15),
-            terminal_altitude_window_m=tuple(cfg["solver"].get("terminal_altitude_window_m", [-5, 5])),
-            terminal_xy_box_m=float(cfg["solver"].get("terminal_xy_box_m", 500.0)),
+            alt_window_m=tuple(cfg["solver"].get("alt_window_m", [-5, 5])),
+            xy_box_m=float(cfg["solver"].get("xy_box_m", 500.0)),
+            alt_slack_penalty=float(cfg["solver"].get("alt_slack_penalty", 0.0)),
+            xy_slack_penalty=float(cfg["solver"].get("xy_slack_penalty", 0.0)),
             osqp_opts=cfg["solver"].get("osqp", {}),
             ecos_opts=cfg["solver"].get("ecos", {}),
         )
@@ -167,8 +171,10 @@ def run_ablation_studies(
             sopts_theta = SolverOptions(
                 enable_soc=True,
                 theta_max_deg=theta,
-                terminal_altitude_window_m=tuple(cfg["solver"].get("terminal_altitude_window_m", [-5, 5])),
-                terminal_xy_box_m=float(cfg["solver"].get("terminal_xy_box_m", 500.0)),
+                alt_window_m=tuple(cfg["solver"].get("alt_window_m", [-5, 5])),
+                xy_box_m=float(cfg["solver"].get("xy_box_m", 500.0)),
+                alt_slack_penalty=float(cfg["solver"].get("alt_slack_penalty", 0.0)),
+                xy_slack_penalty=float(cfg["solver"].get("xy_slack_penalty", 0.0)),
                 osqp_opts=cfg["solver"].get("osqp", {}),
                 ecos_opts=cfg["solver"].get("ecos", {}),
             )
@@ -520,8 +526,10 @@ def run_once(args: argparse.Namespace) -> None:
     sopts_qp = SolverOptions(
         enable_soc=False,
         theta_max_deg=cfg["solver"].get("theta_max_deg", 15),
-        terminal_altitude_window_m=tuple(cfg["solver"].get("terminal_altitude_window_m", [-5, 5])),
-        terminal_xy_box_m=float(cfg["solver"].get("terminal_xy_box_m", 500.0)),
+        alt_window_m=tuple(cfg["solver"].get("alt_window_m", [-5, 5])),
+        xy_box_m=float(cfg["solver"].get("xy_box_m", 500.0)),
+        alt_slack_penalty=float(cfg["solver"].get("alt_slack_penalty", 0.0)),
+        xy_slack_penalty=float(cfg["solver"].get("xy_slack_penalty", 0.0)),
         osqp_opts=cfg["solver"].get("osqp", {}),
         ecos_opts=cfg["solver"].get("ecos", {}),
     )


### PR DESCRIPTION
## Summary
- allow altitude and XY terminal bounds via config parameters `alt_window_m` and `xy_box_m`
- optionally soften terminal constraints with quadratic slack penalties

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8cedb9483298d72df9228fc8094